### PR TITLE
Fix to a subtle bug in recyclerviews with very long datasets

### DIFF
--- a/app/src/main/java/me/adamstroud/devicedatabase/device/DeviceListActivity.java
+++ b/app/src/main/java/me/adamstroud/devicedatabase/device/DeviceListActivity.java
@@ -310,34 +310,37 @@ public class DeviceListActivity extends AppCompatActivity implements LoaderManag
         @Override
         public void onBindViewHolder(DeviceViewHolder holder,
                                      int position) {
-            if (deviceCursor != null
-                    && deviceCursor.moveToPosition(position)) {
-                String model = deviceCursor
-                        .getString(deviceCursor
-                                .getColumnIndexOrThrow(DevicesContract
-                                        .DeviceManufacturer
-                                        .MODEL));
-
-                int deviceId = deviceCursor
-                        .getInt(deviceCursor
-                                .getColumnIndexOrThrow(DevicesContract
-                                        .DeviceManufacturer
-                                        .DEVICE_ID));
-
-                String shortName = deviceCursor
-                        .getString(deviceCursor
-                                .getColumnIndexOrThrow(DevicesContract
-                                        .DeviceManufacturer
-                                        .SHORT_NAME));
-
-                holder.name.setText(getString(R.string.device_name,
-                        shortName,
-                        model,
-                        deviceId));
-                holder.uri = ContentUris
-                        .withAppendedId(DevicesContract.Device.CONTENT_URI,
-                                        deviceId);
+            if (deviceCursor == null) {
+                throw new IllegalStateException("Cursor is null");
             }
+            if (!deviceCursor.moveToPosition(position)) {
+                throw new IllegalStateException("Couldn't move to position " + position);
+            }
+            String model = deviceCursor
+                    .getString(deviceCursor
+                            .getColumnIndexOrThrow(DevicesContract
+                                    .DeviceManufacturer
+                                    .MODEL));
+
+            int deviceId = deviceCursor
+                    .getInt(deviceCursor
+                            .getColumnIndexOrThrow(DevicesContract
+                                    .DeviceManufacturer
+                                    .DEVICE_ID));
+
+            String shortName = deviceCursor
+                    .getString(deviceCursor
+                            .getColumnIndexOrThrow(DevicesContract
+                                    .DeviceManufacturer
+                                    .SHORT_NAME));
+
+            holder.name.setText(getString(R.string.device_name,
+                    shortName,
+                    model,
+                    deviceId));
+            holder.uri = ContentUris
+                    .withAppendedId(DevicesContract.Device.CONTENT_URI,
+                            deviceId);
         }
 
         @Override

--- a/app/src/main/java/me/adamstroud/devicedatabase/manufacturer/ManufacturerListActivity.java
+++ b/app/src/main/java/me/adamstroud/devicedatabase/manufacturer/ManufacturerListActivity.java
@@ -108,13 +108,16 @@ public class ManufacturerListActivity extends AppCompatActivity implements Loade
         @Override
         public void onBindViewHolder(ManufacturerViewHolder holder, int position) {
             final ContentValues contentValues = new ContentValues();
-
-            if (cursor != null && cursor.moveToPosition(position)) {
-                holder.longNameView.setText(cursor.getString(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer.LONG_NAME)));
-                holder.shortNameView.setText(cursor.getString(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer.SHORT_NAME)));
-                holder.uri = ContentUris.withAppendedId(DevicesContract.Manufacturer.CONTENT_URI,
-                        cursor.getLong(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer._ID)));
+            if (cursor == null) {
+                throw new IllegalStateException("Cursor is null");
             }
+            if (!cursor.moveToPosition(position)) {
+                throw new IllegalStateException("Couldn't move to position " + position);
+            }
+            holder.longNameView.setText(cursor.getString(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer.LONG_NAME)));
+            holder.shortNameView.setText(cursor.getString(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer.SHORT_NAME)));
+            holder.uri = ContentUris.withAppendedId(DevicesContract.Manufacturer.CONTENT_URI,
+                    cursor.getLong(cursor.getColumnIndexOrThrow(DevicesContract.Manufacturer._ID)));
         }
 
         @Override


### PR DESCRIPTION
When the dataset is long enough to make you scroll, views are recycled in an anomalous way, with the first subset of data repeated infinitely until the end. This happens because currently there's no alternative to the `if (cursor.moveToPosition(position))` branch, it doesn't fail fast and the view is not repopulated with the correct data for the new position. I've applied this fix to my app now, that displays a dataset containing hundreds of elements, and it works like a charm.